### PR TITLE
Update upload.js

### DIFF
--- a/server/controllers/upload.js
+++ b/server/controllers/upload.js
@@ -256,7 +256,7 @@ async function extractIpaIcon(filename, guid, team) {
     var iconSuffix = "/" + guid + "_i.png"
     createFolderIfNeeded(path.join(uploadDir, iconRelatePath))
     if (stdout.indexOf('not an -iphone crushed PNG file') != -1) {
-        await fs.renameSync(tmpOut, path.join(iconRelatePath, iconSuffix))
+        await fs.renameSync(tmpOut, path.join(uploadDir, iconRelatePath, iconSuffix))
         return { 'success': true, 'fileName': iconRelatePath + iconSuffix }
     }
     await fs.unlinkSync(tmpOut)


### PR DESCRIPTION
{ Error: ENOENT: no such file or directory, rename '/usr/local/LoveFabu/upload/temp/cn.com.dphotos.fans.dev_1.0.1_1901.184.png' -> '5c63d5db4708a2547be17344/icon/cn.com.dphotos.fans.dev_1.0.1_1901.184_i.png'
    at Object.fs.renameSync (fs.js:766:18)
    at extractIpaIcon (/usr/local/LoveFabu/server/controllers/upload.js:261:18)
    at <anonymous>
  errno: -2,
  code: 'ENOENT',
  syscall: 'rename',
  path: '/usr/local/LoveFabu/upload/temp/cn.com.dphotos.fans.dev_1.0.1_1901.184.png',
  dest: '5c63d5db4708a2547be17344/icon/cn.com.dphotos.fans.dev_1.0.1_1901.184_i.png' }